### PR TITLE
Use DeepSpike Release v0.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ target/
 
 #virtualenv
 venv/
+Data
+
+.idea

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ scikit-learn
 pytest
 IPython
 -e git+http://github.com/petered/plato@0.0.3#egg=plato
--e git+http://github.com/petered/deepspike@rename#egg=deepspike
+-e git+http://github.com/petered/deepspike@v0.0.1#egg=deepspike
 git+http://github.com/originell/jpype@v0.6.1#egg=jpype

--- a/spiking_mlp/jpype_connect.py
+++ b/spiking_mlp/jpype_connect.py
@@ -111,7 +111,7 @@ def register_java_class_path(class_path):
         assert isinstance(class_path, (list, tuple)), "class_path should either be a string or a list/tuple"
 
     for cp in class_path:
-        assert os.path.exists(cp), "Java Class path: %s does not exist" % (cp, )
+        assert os.path.exists(cp), "Java Class path: %s does not exist.  Did you forget to compile the Java code?" % (cp, )
 
     global _JAVA_CLASS_PATH
     _JAVA_CLASS_PATH += class_path


### PR DESCRIPTION
This patch updates it so that spiking-mlp actually uses a release of deepspike (rather than a branch).  Which makes everything more stable.
